### PR TITLE
feature/refactor-home-page-deliveries

### DIFF
--- a/lib/bloc/user_bloc/user_bloc.dart
+++ b/lib/bloc/user_bloc/user_bloc.dart
@@ -42,6 +42,19 @@ class UserBloc extends Bloc<UserEvent, UserState> {
         emit(DriverUpcomingTripsLoaded(driverTrips));
       }
 
+      if (event is GetUpcomingRides) {
+        if (!event.forceRefresh && _cachedDriverTrips != null) {
+          emit(UpcomingRidesLoaded(_cachedDriverTrips!));
+          return;
+        }
+
+        List<Trip> trips = [];
+        emit(ProcessStarted());
+        trips = await TripService().getAllUpcomingTrips();
+        _cachedDriverTrips = trips;
+        emit(UpcomingRidesLoaded(trips));
+      }
+
       if (event is GetDriverUpcomingDeliveries) {
         if (!event.forceRefresh && _cachedDriverDeliveries != null) {
           emit(DriverUpcomingDeliveriesLoaded(_cachedDriverDeliveries!));

--- a/lib/bloc/user_bloc/user_event.dart
+++ b/lib/bloc/user_bloc/user_event.dart
@@ -7,6 +7,12 @@ sealed class UserEvent extends Equatable {
   List<Object> get props => [];
 }
 
+class GetUpcomingRides extends UserEvent {
+  final bool forceRefresh;
+
+  const GetUpcomingRides({this.forceRefresh = false});
+}
+
 class GetDriverUpcomingRides extends UserEvent {
   final bool forceRefresh;
 

--- a/lib/bloc/user_bloc/user_state.dart
+++ b/lib/bloc/user_bloc/user_state.dart
@@ -25,6 +25,12 @@ class DriverUpcomingDeliveriesLoaded extends UserState {
   const DriverUpcomingDeliveriesLoaded(this.driverDeliveries);
 }
 
+class UpcomingRidesLoaded extends UserState {
+  final List<Trip> trips;
+
+  const UpcomingRidesLoaded(this.trips);
+}
+
 class DriverDataLoaded extends UserState {
   final List<Trip> driverTrips;
   final List<TaskTripDTO> driverDeliveries;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,10 +8,12 @@ import 'package:travel_app/bloc/map_bloc/map_bloc.dart';
 import 'package:travel_app/bloc/user_bloc/user_bloc.dart';
 import 'package:travel_app/presentation/screens/add_delivery_screen.dart';
 import 'package:travel_app/presentation/screens/add_ride_screen.dart';
+import 'package:travel_app/presentation/screens/delivery_details_screen.dart';
 import 'package:travel_app/presentation/screens/login_screen.dart';
 import 'package:travel_app/presentation/screens/my_rides_screen.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:travel_app/presentation/screens/register_screen.dart';
+import 'package:travel_app/presentation/screens/reserve_delivery_screen.dart';
 import 'package:travel_app/presentation/screens/reserve_ride_screen.dart';
 import 'package:travel_app/presentation/screens/ride_details_screen.dart';
 import 'package:travel_app/utils/string_constants.dart';
@@ -46,8 +48,11 @@ class MyApp extends StatelessWidget {
       initialRoute: "/home",
       routes: {
         "/home": (context) => const MyHomePage(),
-        "/details": (context) => RideDetailsScreen(),
+        "/rideDetails": (context) => RideDetailsScreen(),
+        //TODO change to delivery details screen
+        "/deliveryDetails": (context) => DeliveryDetailsScreen(),
         "/reserveRide": (context) => ReserveRideScreen(),
+        "/reserveDelivery": (context) => ReserveDeliveryScreen(),
         "/addRide": (context) {
           context.read<UserBloc>().add(LoadDrivers());
           return AddRideScreen();

--- a/lib/presentation/screens/delivery_details_screen.dart
+++ b/lib/presentation/screens/delivery_details_screen.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+import '../widgets/custom_app_bar.dart';
+
+class DeliveryDetailsScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: customAppBar(context: context, arrowBack: true),
+      body: Text("Delivery screen details"),
+    );
+  }
+}

--- a/lib/presentation/screens/reserve_delivery_screen.dart
+++ b/lib/presentation/screens/reserve_delivery_screen.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+import '../widgets/custom_app_bar.dart';
+
+class ReserveDeliveryScreen extends StatefulWidget {
+  const ReserveDeliveryScreen({super.key});
+
+  @override
+  State<ReserveDeliveryScreen> createState() => _ReserveDeliveryScreenState();
+}
+
+class _ReserveDeliveryScreenState extends State<ReserveDeliveryScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: customAppBar(context: context, arrowBack: true),
+      body: Text("reserve delivery screen"),
+    );
+  }
+}

--- a/lib/presentation/widgets/rides_widget.dart
+++ b/lib/presentation/widgets/rides_widget.dart
@@ -5,6 +5,7 @@ import 'package:marquee/marquee.dart';
 import 'package:travel_app/bloc/auth_bloc/auth_bloc.dart';
 import 'package:travel_app/data/enums/user_role.dart';
 import 'package:travel_app/presentation/widgets/custom_arrow_button.dart';
+import 'package:travel_app/utils/color_constants.dart';
 import 'package:travel_app/utils/string_constants.dart';
 import 'package:travel_app/utils/text_styles.dart';
 
@@ -16,12 +17,13 @@ import '../../utils/functions.dart';
 class RidesWidget extends StatelessWidget {
   final BuildContext context;
   final Trip ride;
+  final bool isRidesScreen;
 
-  const RidesWidget({
-    super.key,
-    required this.context,
-    required this.ride,
-  });
+  const RidesWidget(
+      {super.key,
+      required this.context,
+      required this.ride,
+      this.isRidesScreen = false});
 
   @override
   Widget build(BuildContext context) {
@@ -109,19 +111,35 @@ class RidesWidget extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.end,
       children: [
-        Row(
-          children: [
-            const Icon(
-              Icons.people_alt_outlined,
-              size: 14,
-            ),
-            const SizedBox(width: 4),
-            Text(
-              "${ride.maxCapacity - ride.passengerTrips.length} Places left",
-              style: StyledText().descriptionText(fontSize: 12),
-            ),
-          ],
-        ),
+        isRidesScreen
+            ? Row(
+                children: [
+                  const Icon(
+                    Icons.people_alt_outlined,
+                    size: 14,
+                  ),
+                  const SizedBox(width: 4),
+                  Text(
+                    "${ride.maxCapacity - ride.passengerTrips.length} Places left",
+                    style: StyledText().descriptionText(fontSize: 12),
+                  )
+                ],
+              )
+            : Row(
+                children: [
+                  const Icon(
+                    Icons.monetization_on_outlined,
+                    color: greenColor,
+                    size: 14,
+                  ),
+                  const SizedBox(width: 4),
+                  Text(
+                    "${ride.deliveryPrice}",
+                    style: StyledText().descriptionText(fontSize: 12),
+                  ),
+                  const SizedBox(width: 10),
+                ],
+              ),
         const SizedBox(height: 8),
         BlocBuilder<AuthBloc, AuthState>(builder: (context, state) {
           if (state is UserIsLoggedIn) {
@@ -129,9 +147,10 @@ class RidesWidget extends StatelessWidget {
           }
           return customArrowButton(
             text: userRole == UserRole.CLIENT
-                ? AppStrings.reserve
+                ? (isRidesScreen ? AppStrings.reserve : "Send Package")
                 : AppStrings.viewDetails,
             fontSize: 12,
+            horizontalPadding: 20,
             onPressed: () {
               Functions.emitUserEvent(
                   context: context,
@@ -140,9 +159,8 @@ class RidesWidget extends StatelessWidget {
                       : GetTripDetails(
                           driverId: trip.driverId, tripId: trip.id));
               userRole == UserRole.CLIENT
-                  ? Navigator.pushNamed(context, "/reserveRide",
-                      arguments: trip)
-                  : Navigator.pushNamed(context, "/details", arguments: trip);
+                  ? Navigator.pushNamed(context, isRidesScreen ? "/reserveRide" : "/reserveDelivery", arguments: trip)
+                  : Navigator.pushNamed(context, isRidesScreen ? "/rideDetails" : "/deliveryDetails", arguments: trip);
             },
           );
         }),


### PR DESCRIPTION
Refactored the home screen deliveries. Changed the events, so they are not `GetDriverUpcomingRides`, now they publish `GetUpcomingRides` events when the user selects `Rides` or `Deliveries`. I also added `UpcomingRidesLoaded ` for consistency and to avoid having a lot of merge conflicts. This can be changed later, we can refactor the events a bit, to not have so many.
In the home page i also refactored the part where it showed different widgets for deliveries and rides, now it shows the same rides widget with different labels.
Rides widget now has a variable that tells it whether its rides or deliveries screen, for the labels and button redirects.
Added initial screens for delivery details and delivery reservation which need to be implemented.